### PR TITLE
Create tmp/0 before test kinit- if not exists it fails to test

### DIFF
--- a/vaulty-sup.py
+++ b/vaulty-sup.py
@@ -398,6 +398,11 @@ if __name__ == '__main__':
     if args.kinit:
         secrets = read_secret(args.kinit)
         if secrets is not None:
+            try:
+                os.mkdir('/tmp/0')
+            except FileExistsError:
+                continue
+
             for key, value in secrets['data'].items():
                 if key.endswith("keytab"):
                     fd, path = mkstemp()


### PR DESCRIPTION
When testing kinit sometimes it fails even if the secret is correct, the problem is that tmp/0 directory doesn't exists